### PR TITLE
ERM-1611: Bugfixes

### DIFF
--- a/src/components/TypeComponents/SimpleSearch/Form/filters/SimpleSearchFilterField.js
+++ b/src/components/TypeComponents/SimpleSearch/Form/filters/SimpleSearchFilterField.js
@@ -82,7 +82,7 @@ const SimpleSearchFilterField = ({ filterColumns, id, input: { name } }) => {
       break;
   }
 
-  // Keep the hidden form field up to date
+  // Keep the hidden form fields up to date
   useEffect(() => {
     change(`${name}.fieldType`, selectedFilterColumn?.valueType);
     change(`${name}.resourceType`, selectedFilterColumn?.resource);

--- a/src/components/TypeComponents/SimpleSearch/Form/filters/SimpleSearchFilterField.js
+++ b/src/components/TypeComponents/SimpleSearch/Form/filters/SimpleSearchFilterField.js
@@ -8,6 +8,8 @@ import { get } from 'lodash';
 import { Field, useForm, useFormState } from 'react-final-form';
 import { FieldArray } from 'react-final-form-arrays';
 
+import { useModules, useStripes } from '@folio/stripes/core';
+
 import {
   Datepicker,
   KeyValue,
@@ -24,6 +26,9 @@ import SimpleSearchFilterRuleArray from './SimpleSearchFilterRuleArray';
 const SimpleSearchFilterField = ({ filterColumns, id, input: { name } }) => {
   const { values } = useFormState();
   const { change } = useForm();
+
+  const stripes = useStripes();
+  const { plugin: modulePlugins } = useModules();
 
   // Create values for available filters. If label available use that, else use name
   const selectifiedFilterNames = [{ value: '', label: '', disabled: true }, ...filterColumns.map(fc => ({ value: fc.name, label: fc.label ?? fc.name }))];
@@ -61,7 +66,11 @@ const SimpleSearchFilterField = ({ filterColumns, id, input: { name } }) => {
 
       let LookupComponent = resourceReg?.getLookupComponent();
 
-      if (selectedFilterColumn.resource === 'user' && !LookupComponent) {
+      // TODO isEnabled for plugins/modules is something that should be exposed, perhaps via the registry
+      const findUserPluginAvailable = !!modulePlugins?.find(p => p.pluginType === 'find-user') &&
+        stripes.hasPerm('module.ui-plugin-find-user.enabled');
+
+      if (selectedFilterColumn.resource === 'user' && !LookupComponent && findUserPluginAvailable) {
         // USER does not have a lookup component in the registry, fallback to known user lookup for now
         LookupComponent = UserLookup;
       }

--- a/src/components/TypeComponents/SimpleSearch/Form/filters/SimpleSearchFilterRuleField.js
+++ b/src/components/TypeComponents/SimpleSearch/Form/filters/SimpleSearchFilterRuleField.js
@@ -53,7 +53,6 @@ const SimpleSearchFilterRuleField = ({
         filterComponent={filterComponent}
         filterComponentProps={filterComponentProps}
         input={{ name }}
-        resourceType={resource}
         selectifiedComparators={selectifiedComparators}
       />
     );
@@ -66,6 +65,7 @@ const SimpleSearchFilterRuleField = ({
         filterComponent={filterComponent}
         filterComponentProps={filterComponentProps}
         input={{ name }}
+        resourceType={resource}
         selectifiedComparators={selectifiedComparators}
       />
     );

--- a/src/components/TypeComponents/SimpleSearch/Form/filters/SimpleSearchUUIDFilterField.js
+++ b/src/components/TypeComponents/SimpleSearch/Form/filters/SimpleSearchUUIDFilterField.js
@@ -35,7 +35,6 @@ const SimpleSearchUUIDFilterField = ({
 
   // Resource variable for UUID case
   const [resource, setResource] = useState(get(initialValues, `${name}.resource`) ?? {});
-  // Keep hidden field up to date
   // This field is used when editing the widget, to display existing resource data
   useEffect(() => {
     change(`${name}.resource`, resource);


### PR DESCRIPTION
Fixes to user lookup - now renders alongside user token work.
Fixes to systems which don't have the user lookup plugin - now checks module exists and user has perm to view it

NOTE
this problem is only _half_ solved for registry stuff. We may need a "perms required" check or something built into registry methods.