### PR TITLE
EMR-1654: Including special characters in a SimpleSearch filter string causes issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for ui-dashboard
 
 ## 1.0.0 In progress
+* Added URI encoding to filter strings to deal with special characters.
 * Added framework for Registry. ERM-1611
 * Code Cleanup. ERM-1625
   * final-form config changes and form bug fixes

--- a/src/components/TypeComponents/SimpleSearch/Widget/simpleSearchPathBuilder.js
+++ b/src/components/TypeComponents/SimpleSearch/Widget/simpleSearchPathBuilder.js
@@ -89,7 +89,9 @@ const simpleSearchPathBuilder = (widgetDef, widgetConf, stripes) => {
           // If we're allowing null the filterString is slightly different
           specificFilterString += `${filterPath} ${r.comparator}`;
         } else {
-          specificFilterString += `${filterPath}${r.comparator}${tokens(r.filterValue, stripes)}`;
+          // Ensure we're safely encoding all special characters into the filters path
+          const encodedFilterValue = encodeURI(r.filterValue);
+          specificFilterString += `${filterPath}${r.comparator}${tokens(encodedFilterValue, stripes)}`;
         }
 
         if (ind !== rules.length - 1) {

--- a/src/components/Widget/Widget.test.js
+++ b/src/components/Widget/Widget.test.js
@@ -8,10 +8,15 @@ const widget = {
   id: '12345'
 };
 
+const onWidgetEdit = jest.fn(() => null);
+const onWidgetDelete = jest.fn(() => null);
+
 describe('Widget', () => {
   test('renders expected widget name', () => {
     const { getByText } = renderWithIntl(
       <Widget
+        onWidgetDelete={onWidgetDelete}
+        onWidgetEdit={onWidgetEdit}
         widget={widget}
       >
         <div> Test body </div>
@@ -24,6 +29,8 @@ describe('Widget', () => {
   test('renders expected widget content', () => {
     const { getByText } = renderWithIntl(
       <Widget
+        onWidgetDelete={onWidgetDelete}
+        onWidgetEdit={onWidgetEdit}
         widget={widget}
       >
         <div> Test body </div>


### PR DESCRIPTION
- Added uri encoding to filter strings to deal with special characters.
- Fixes to test