### PR TITLE
ERM-1894 upgrade react-intl-safe-html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Change history for ui-dashboard
 
 ## 2.1.0 In progress
-* UX improvements for Dashboard. ERM-1792, ERM-1855
+  * UX improvements for Dashboard. ERM-1792, ERM-1855
+  * Upgrade `@folio/react-intl-safe-html` for compatibility with `@folio/stripes` `v7`. ERM-1894
+
 ## 2.0.0 2021-10-07
   * Upgrade to stripes v7
   * Improve the date filter comparator UX. ERM-1648, ERM-1839, ERM-1840

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "sinon": "^9.0.2"
   },
   "dependencies": {
-    "@folio/react-intl-safe-html": "^2.0.0",
+    "@folio/react-intl-safe-html": "^3.1.0",
     "@folio/stripes-erm-components": "^6.0.0",
     "@folio/handler-stripes-registry": "^1.0.0",
     "classnames": "^2.2.6",


### PR DESCRIPTION
Upgrade `@folio/react-intl-safe-html` for compatibility with
`@folio/stripes` `v7` (react 17, react-intl 5).

@EthanFreestone, @CalamityC, @aditya-matukumalli:  I don't have write privs in this repo to add PR reviewers. If this looks good to you, please merge it. Thanks!

Refs [ERM-1894](https://issues.folio.org/browse/ERM-1894), [STRIPES-769](https://issues.folio.org/browse/STRIPES-769)