### PR TITLE
Revert "ERM-2312: Managed Dashboards: backend model (refactor to avoid regressions)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change history for ui-dashboard
-## 3.0.0 In progress
-  * ERM-2312 Managed Dashboards: backend model (refactor to avoid regressions)
+## 2.3.0 In progress
+
 ## 2.2.0 2022-07-04
   * ERM-2122 Remove Dashboard icon in settings section
   * ERM-2107 / ERM-2085 Refactor away from react-intl-safe-html

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/dashboard",
-  "version": "3.0.0",
+  "version": "2.3.0",
   "description": "Dashboard app for configurable FOLIO widgets",
   "main": "src/index.js",
   "repository": "",
@@ -29,11 +29,10 @@
     "hasSettings": true,
     "queryResource": "query",
     "okapiInterfaces": {
-      "servint": "2.0"
+      "servint": "1.0"
     },
     "stripesDeps": [
-      "@folio/stripes-erm-components",
-      "@k-int/stripes-kint-components"
+      "@folio/stripes-erm-components"
     ],
     "icons": [
       {
@@ -52,9 +51,7 @@
         "permissionName": "settings.dashboard.enabled",
         "displayName": "Settings (dashboard): display list of settings pages",
         "subPermissions": [
-          "settings.enabled",
-          "servint.settings.write",
-          "servint.refdata.write"
+          "settings.enabled"
         ],
         "visible": false
       },
@@ -65,15 +62,6 @@
         "subPermissions": [
           "module.dashboard.enabled",
           "servint.dashboards.manage"
-        ],
-        "visible": true
-      },
-      {
-        "permissionName": "ui-dashboard.dashboards.admin",
-        "displayName": "Dashboard: Dashboard administrator",
-        "description": "A user with this permission has no user-based restrictions on which dashboards and widgets they can interact with, ie create/delete/update",
-        "subPermissions": [
-          "servint.dashboards.admin"
         ],
         "visible": true
       }
@@ -134,7 +122,6 @@
   },
   "dependencies": {
     "@folio/stripes-erm-components": "^6.2.0",
-    "@k-int/stripes-kint-components": "^2.8.2",
     "classnames": "^2.2.6",
     "compose-function": "^3.0.3",
     "final-form": "^4.19.0",

--- a/src/index.js
+++ b/src/index.js
@@ -78,10 +78,10 @@ const App = ({ history, location, match: { path } }) => {
             )}
           </AppContextMenu>
           <Switch>
-            <Route component={WidgetCreateRoute} path={`${path}/:dashId/create`} />
-            <Route component={WidgetEditRoute} path={`${path}/:dashId/:widgetId/edit`} />
-            <Route component={DashboardOrderRoute} path={`${path}/:dashId/editOrder`} />
-            <Route component={DashboardRoute} path={`${path}/:dashId`} />
+            <Route component={WidgetCreateRoute} path={`${path}/:dashName/create`} />
+            <Route component={WidgetEditRoute} path={`${path}/:dashName/:widgetId/edit`} />
+            <Route component={DashboardOrderRoute} path={`${path}/:dashName/editOrder`} />
+            <Route component={DashboardRoute} path={`${path}/:dashName`} />
             <Route component={DashboardsRoute} path={path} />
           </Switch>
         </HasCommand>

--- a/src/routes/DashboardOrderRoute.js
+++ b/src/routes/DashboardOrderRoute.js
@@ -13,22 +13,22 @@ const DashboardOrderRoute = ({
   history,
   match: {
     params: {
-      dashId
+      dashName
     }
   }
 }) => {
   const ky = useOkapiKy();
 
-  // Load specific dashboard
-  const { data: dashboard, isLoading: dashboardLoading } = useQuery(
+  // Load specific dashboard from name
+  const { data: { 0: dashboard } = [], isLoading: dashboardLoading } = useQuery(
     ['ui-dashboard', 'dashboardOrderRoute', 'dashboard'],
-    () => ky(`servint/dashboard/${dashId}`).json(),
+    () => ky(`servint/dashboard/my-dashboards?filters=name=${dashName}`).json(),
   );
 
   // The PUT for the dashboardOrdering
   const { mutateAsync: putDashOrder } = useMutation(
     ['ui-dashboard', 'dashboardOrderRoute', 'putDashboard'],
-    (data) => ky.put(`servint/dashboard/${dashId}`, { json: data })
+    (data) => ky.put(`servint/dashboard/${dashboard?.id}`, { json: data })
   );
 
   if (dashboardLoading) {
@@ -38,7 +38,7 @@ const DashboardOrderRoute = ({
   }
 
   const handleClose = () => {
-    history.push(`/dashboard/${dashId}`);
+    history.push(`/dashboard/${dashName}`);
   };
 
   const doTheSubmit = (values) => (
@@ -85,7 +85,7 @@ DashboardOrderRoute.propTypes = {
   }).isRequired,
   match: PropTypes.shape({
     params: PropTypes.shape({
-      dashId: PropTypes.string
+      dashName: PropTypes.string
     })
   }).isRequired
 };

--- a/src/routes/DashboardRoute.js
+++ b/src/routes/DashboardRoute.js
@@ -19,15 +19,15 @@ const DashboardRoute = ({
   }
 }) => {
   const ky = useOkapiKy();
-  const [dashId, setDashId] = useState(params.dashId);
+  const [dashName, setDashName] = useState(params.dashName);
 
   // Load specific dashboard -- for now will only be DEFAULT
   const [isInitialCallFinished, setInitialCallFinished] = useState(false);
-  const { data: dashboard, isLoading: dashboardLoading, refetch: refetchDashboard } = useQuery(
+  const { data: { 0: dashboard } = [], isLoading: dashboardLoading, refetch: refetchDashboard } = useQuery(
     ['ui-dashboard', 'dashboardRoute', 'dashboard'],
     async () => {
       // Actually wait for the data to come back.
-      const dashData = await ky(`servint/dashboard/${dashId}`).json();
+      const dashData = await ky(`servint/dashboard/my-dashboards?filters=name=${dashName}`).json();
       setInitialCallFinished(true);
       return dashData;
     }
@@ -37,7 +37,7 @@ const DashboardRoute = ({
   const { data: widgets, isLoading: widgetsLoading } = useQuery(
     // We need this to rerun when the dashboard updates
     ['ui-dashboard', 'dashboardRoute', 'widgets', dashboard],
-    () => ky(`servint/dashboard/${dashId}/widgets?sort=weight;asc&perPage=100`).json(),
+    () => ky(`servint/widgets/instances/my-widgets?filters=owner.id=${dashboard?.id}&sort=weight;asc&perPage=100`).json(),
     {
       /* Once the dashboard has been fetched, we can then fetch the ordered list of widgets from it */
       enabled: (
@@ -82,7 +82,7 @@ const DashboardRoute = ({
       <Dashboard
         key={`dashboard-${dashboard.id}`}
         dashboardId={dashboard.id}
-        onChangeDash={setDashId}
+        onChangeDash={setDashName}
         onCreate={handleCreate}
         onReorder={handleReorder}
         onWidgetDelete={handleWidgetDelete}
@@ -93,7 +93,7 @@ const DashboardRoute = ({
   }
   return (
     <ErrorPage>
-      <FormattedMessage id="ui-dashboard.error.noDashWithThatName" values={{ name: dashboard?.name }} />
+      <FormattedMessage id="ui-dashboard.error.noDashWithThatName" values={{ name: dashName }} />
     </ErrorPage>
   );
 };
@@ -110,7 +110,7 @@ DashboardRoute.propTypes = {
   }).isRequired,
   match: PropTypes.shape({
     params: PropTypes.shape({
-      dashId: PropTypes.string
+      dashName: PropTypes.string
     })
   }).isRequired
 };

--- a/src/routes/DashboardsRoute.js
+++ b/src/routes/DashboardsRoute.js
@@ -1,10 +1,8 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 
 import { useQuery } from 'react-query';
-import { generateKiwtQueryParams } from '@k-int/stripes-kint-components';
-
 import { useOkapiKy } from '@folio/stripes/core';
 
 import Loading from '../components/Dashboard/Loading';
@@ -21,35 +19,13 @@ const DashboardsRoute = ({
    */
 
   const ky = useOkapiKy();
-  const myDashboardsQueryParams = useMemo(() => (
-    generateKiwtQueryParams(
-      {
-        sort: [
-          {
-            path: 'defaultUserDashboard',
-            direction: 'desc'
-          },
-          {
-            path: 'userDashboardWeight'
-          },
-          {
-            path: 'dateCreated',
-            direction: 'desc'
-          }
-        ],
-        stats: false
-      },
-      {}
-    )
-  ), []);
   // At some point we might have a select for different dashboards here, hence this generic call as well as the specific one
-  // For now ensure we always get the dashboards back from earliest to latest
   const [isInitialDashFinished, setInitialDashFinished] = useState(false);
   const { data: dashboards, isLoading: dashboardsLoading } = useQuery(
-    ['ui-dashboard', 'dashboardRoute', 'dashboards', myDashboardsQueryParams],
+    ['ui-dashboard', 'dashboardRoute', 'dashboards'],
     async () => {
       // Actually wait for the data to come back.
-      const dashData = await ky(`servint/dashboard/my-dashboards?${myDashboardsQueryParams.join('&')}`).json();
+      const dashData = await ky('servint/dashboard/my-dashboards').json();
       setInitialDashFinished(true);
       return dashData;
     }
@@ -61,8 +37,8 @@ const DashboardsRoute = ({
        * NOTE this simply pushes the user to the first dashboard in their list,
        * which initially should only be a single dashboard, DEFAULT
        */
-      const dashId = dashboards[0]?.dashboard?.id;
-      history.push(`/dashboard/${dashId}`);
+      const dashName = dashboards[0]?.name;
+      history.push(`/dashboard/${dashName}`);
     }
   }, [dashboards, history, isInitialDashFinished]);
 

--- a/src/routes/WidgetCreateRoute.js
+++ b/src/routes/WidgetCreateRoute.js
@@ -18,9 +18,9 @@ const WidgetCreateRoute = ({
 }) => {
   const ky = useOkapiKy();
   // Query setup for the dashboard/definitions/POST/PUT
-  const { data: dashboard = {} } = useQuery(
+  const { data: { 0: dashboard = {} } = [] } = useQuery(
     ['ui-dashboard', 'widgetCreateRoute', 'getDash'],
-    () => ky(`servint/dashboard/${params.dashId}`).json()
+    () => ky(`servint/dashboard/my-dashboards?filters=name=${params.dashName}`).json()
   );
 
   const { mutateAsync: postWidget } = useMutation(
@@ -48,7 +48,7 @@ const WidgetCreateRoute = ({
 
   const handleClose = (id) => {
     history.push({
-      pathname: `/dashboard/${params.dashId}`,
+      pathname: `/dashboard/${params.dashName}`,
       ...(id && { state: id })
     });
   };
@@ -121,7 +121,7 @@ WidgetCreateRoute.propTypes = {
   }).isRequired,
   match: PropTypes.shape({
     params: PropTypes.shape({
-      dashId: PropTypes.string,
+      dashName: PropTypes.string,
       widgetId: PropTypes.string,
     })
   }).isRequired

--- a/src/routes/WidgetEditRoute.js
+++ b/src/routes/WidgetEditRoute.js
@@ -9,6 +9,7 @@ import { useMutation, useQuery } from 'react-query';
 import WidgetForm from '../components/WidgetForm';
 import getComponentsFromType from '../components/getComponentsFromType';
 
+
 const WidgetEditRoute = ({
   history,
   match: {
@@ -17,9 +18,9 @@ const WidgetEditRoute = ({
 }) => {
   const ky = useOkapiKy();
   // Query setup for the dashboard/definitions/POST/PUT
-  const { data: dashboard = {} } = useQuery(
+  const { data: { 0: dashboard = {} } = [] } = useQuery(
     ['ui-dashboard', 'widgetCreateRoute', 'getDash'],
-    () => ky(`servint/dashboard/${params.dashId}`).json()
+    () => ky(`servint/dashboard/my-dashboards?filters=name=${params.dashName}`).json()
   );
 
   const { mutateAsync: putWidget } = useMutation(
@@ -72,7 +73,7 @@ const WidgetEditRoute = ({
 
   const handleClose = (id) => {
     history.push({
-      pathname: `/dashboard/${params.dashId}`,
+      pathname: `/dashboard/${params.dashName}`,
       ...(id && { state: id })
     });
   };
@@ -150,7 +151,7 @@ WidgetEditRoute.propTypes = {
   }).isRequired,
   match: PropTypes.shape({
     params: PropTypes.shape({
-      dashId: PropTypes.string,
+      dashName: PropTypes.string,
       widgetId: PropTypes.string,
     })
   }).isRequired


### PR DESCRIPTION
Reverts folio-org/ui-dashboard#173

[As noted on Slack](https://folio-project.slack.com/archives/CFQU1MF61/p1661192912341019): ui-service-interactions (and perhaps other apps) still [rely on servint v1.0](https://github.com/folio-org/ui-service-interaction/blob/2c28aee532bb467041b57eede33bfa2036dbced7/package.json#L28-L30) so [this change broke the build](https://github.com/folio-org/ui-dashboard/pull/173). 