### PR TITLE
ERM-2350: When the user only has one dashboard, display the dashboard name in a header

### DIFF
--- a/src/components/DashboardContainer/Header/Header.js
+++ b/src/components/DashboardContainer/Header/Header.js
@@ -170,10 +170,17 @@ const Header = ({
     );
   };
 
-  return (
-    <div className={css.header}>
-      <div /> {/* Empty start item so we can get centre/end aligned */}
-      {dashboards?.length > 1 &&
+  const renderHeaderCentre = () => {
+    if (dashboards?.length === 1) {
+      return (
+        <Headline>
+          {dashName}
+        </Headline>
+      );
+    }
+
+    if (dashboards?.length > 1) {
+      return (
         <ButtonGroup>
           {dashboards?.map(dba => (
             <Button
@@ -186,7 +193,16 @@ const Header = ({
             </Button>
           ))}
         </ButtonGroup>
-      }
+      );
+    }
+
+    return (<div />);
+  };
+
+  return (
+    <div className={css.header}>
+      <div /> {/* Empty start item so we can get centre/end aligned */}
+      {renderHeaderCentre()}
       <ActionMenu actionMenu={getActionMenu} />
     </div>
   );

--- a/src/components/DashboardContainer/Header/Header.test.js
+++ b/src/components/DashboardContainer/Header/Header.test.js
@@ -40,7 +40,9 @@ const headerProps = {
 jest.mock('../../hooks', () => ({
   ...jest.requireActual('../../hooks'),
   useDashboardAccess: jest.fn()
-    // Each block has two tests so repeat implementation
+    .mockReturnValueOnce({ hasAccess: () => false, hasAdminPerm: false })
+    .mockReturnValueOnce({ hasAccess: () => false, hasAdminPerm: false })
+    // Each access test block has two tests so repeat implementation
     .mockReturnValueOnce({ hasAccess: () => true, hasAdminPerm: false })
     .mockReturnValueOnce({ hasAccess: () => true, hasAdminPerm: false })
     .mockReturnValueOnce({ hasAccess: (acc) => acc === 'edit', hasAdminPerm: false })
@@ -52,6 +54,47 @@ jest.mock('../../hooks', () => ({
 }));
 
 describe('Header', () => {
+  describe('Header with one dashboard', () => {
+    beforeEach(() => {
+      renderWithIntl(
+        <Router>
+          <Header
+            {
+              ...{
+                ...headerProps,
+                dashboards: [dashboardsAccess[0]]
+              }
+            }
+          />
+        </Router>,
+        translationsProperties
+      );
+    });
+
+    test('renders the name of the dashboard in the header', async () => {
+      await Headline('My dashboard').exists();
+    });
+  });
+
+  describe('Header with one dashboard', () => {
+    beforeEach(() => {
+      renderWithIntl(
+        <Router>
+          <Header
+            {...headerProps}
+          />
+        </Router>,
+        translationsProperties
+      );
+    });
+
+    test('renders a ButtonGroup containing all pertinent dashboards', async () => {
+      await Button('My dashboard').exists();
+      await Button('Test dash 1').exists();
+      await Button('Test dash 3').exists();
+    });
+  });
+
   describe('Header with \'manage\' access', () => {
     beforeEach(() => {
       renderWithIntl(


### PR DESCRIPTION
feat: Dashboard Header

When only a single dashboard is present in the dashboards list for a user, display that dashboard's name in the header in place of the buttonGroup switcher

ERM-2350