### PR TITLE
SI-41: Improve error handling

### DIFF
--- a/src/components/ErrorComponents/Error.css
+++ b/src/components/ErrorComponents/Error.css
@@ -25,6 +25,7 @@
   color: var(--color-text-p2);
   background: var(--error-fill);
   min-height: 250px;
+  height: 100%;
   margin-bottom: var(--gutter-static-two-thirds);
   border-radius: var(--radius);
   display: flex;

--- a/src/components/WidgetForm/WidgetForm.js
+++ b/src/components/WidgetForm/WidgetForm.js
@@ -29,6 +29,7 @@ import DashboardMultipleUserInfo from '../DashboardMultipleUserInfo';
 
 const propTypes = {
   data: PropTypes.shape({
+    areDefinitionsLoading: PropTypes.bool,
     name: PropTypes.string,
     params: PropTypes.shape({
       widgetId: PropTypes.string,
@@ -48,6 +49,7 @@ const propTypes = {
 // This component should contain the logic to select a widget definition and push on to a specific widgetForm, ie SimpleSearchForm
 const WidgetForm = ({
   data: {
+    areDefinitionsLoading,
     dashId,
     dashboardUsers = [],
     initialValues,
@@ -199,7 +201,7 @@ const WidgetForm = ({
                 </KeyValue>
               </Col>
             </Row>
-            {selectedDefinition && WidgetFormComponent &&
+            {!areDefinitionsLoading && WidgetFormComponent &&
               <Field
                 name="widgetConfig"
                 render={() => (

--- a/src/hooks/useWidgetDefinition.js
+++ b/src/hooks/useWidgetDefinition.js
@@ -1,7 +1,7 @@
 import { useOkapiKy } from '@folio/stripes/core';
 import { useQuery } from 'react-query';
 
-import { getComponentsFromType } from '../utils';
+import { getComponentsFromDefinition } from '../utils';
 
 /* Hook to expose the definition and consequently
  * the components relevant to that def's type
@@ -18,7 +18,11 @@ const useWidgetDefinition = (defName, defVersion = undefined) => {
     () => ky(`servint/widgets/definitions/global?name=${defName}${defVersion ? '&version=' + defVersion : ''}`).json()
   );
 
-  const componentBundle = getComponentsFromType(specificWidgetDefinition?.type?.name, isFetching);
+  const componentBundle = getComponentsFromDefinition({
+    definitionName: defName,
+    isLoading: isFetching,
+    selectedDefinition: specificWidgetDefinition,
+  });
   return { specificWidgetDefinition, componentBundle };
 };
 

--- a/src/routes/WidgetCreateRoute.js
+++ b/src/routes/WidgetCreateRoute.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useOkapiKy } from '@folio/stripes/core';
 import PropTypes from 'prop-types';
 import { Form } from 'react-final-form';
@@ -6,7 +6,7 @@ import arrayMutators from 'final-form-arrays';
 
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 
-import { getComponentsFromType } from '../utils';
+import { getComponentsFromDefinition } from '../utils';
 
 import WidgetForm from '../components/WidgetForm';
 
@@ -36,7 +36,7 @@ const WidgetCreateRoute = ({
     submitManipulation,
     createInitialValues,
     WidgetFormComponent
-  } = getComponentsFromType(selectedDefinition?.type?.name ?? '');
+  } = getComponentsFromDefinition({ selectedDefinition });
 
   const initialValues = {
     widgetConfig: {
@@ -63,8 +63,8 @@ const WidgetCreateRoute = ({
     });
     // Include other necessary metadata
     const submitValue = {
-      definitionName: selectedDefinition.name,
-      definitionVersion: selectedDefinition.version,
+      definitionName: selectedDefinition?.name ?? '',
+      definitionVersion: selectedDefinition?.version ?? '',
       name,
       owner: { id: dashboard.id },
       configuration: conf

--- a/src/routes/WidgetEditRoute.js
+++ b/src/routes/WidgetEditRoute.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useOkapiKy } from '@folio/stripes/core';
 import PropTypes from 'prop-types';
 import { Form } from 'react-final-form';
@@ -6,7 +6,7 @@ import arrayMutators from 'final-form-arrays';
 
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 
-import { getComponentsFromType } from '../utils';
+import { getComponentsFromDefinition } from '../utils';
 
 import WidgetForm from '../components/WidgetForm';
 
@@ -47,7 +47,7 @@ const WidgetEditRoute = ({
     queryNS.push(widget?.id);
   }
 
-  const { data: widgetDefinitions } = useQuery(
+  const { data: widgetDefinitions, isLoading: areDefinitionsLoading } = useQuery(
     queryNS,
     () => ky(`servint/widgets/definitions/global${widget ? '?name=' + widget.definition?.name + '&version=' + widget.definition?.version : ''}`).json()
   );
@@ -65,7 +65,11 @@ const WidgetEditRoute = ({
     submitManipulation,
     widgetToInitialValues,
     WidgetFormComponent
-  } = getComponentsFromType(selectedDefinition?.type?.name ?? '');
+  } = getComponentsFromDefinition({
+    definitionName: widget?.definition?.name,
+    isLoading: areDefinitionsLoading,
+    selectedDefinition
+  });
 
   let initialValues = {};
   if (widget) {
@@ -126,6 +130,7 @@ const WidgetEditRoute = ({
           <form onSubmit={handleSubmit}>
             <WidgetForm
               data={{
+                areDefinitionsLoading,
                 dashId: params.dashId,
                 dashboardUsers,
                 // Pass initialValues in here so we can manually initialize when they're fetched

--- a/src/utils/getComponentsFromDefinition.js
+++ b/src/utils/getComponentsFromDefinition.js
@@ -1,4 +1,5 @@
 import { FormattedMessage } from 'react-intl';
+
 import { Spinner } from '@folio/stripes/components';
 
 // TODO figure out lazy loading of functions
@@ -19,9 +20,39 @@ import {
 
 import css from '../Style.css';
 
+const noop = (props) => (props);
+
 // This function ensures all of the switching logic between differing WidgetTypes happens in a single place,
 // and then passes the relevant components in a bundled object.
-const getComponentsFromType = (widgetType = '', isLoading = false) => {
+
+const getComponentsFromDefinition = ({
+  // Can pass definitionName OPTIONALLY, if passed it'll use for error where definition couldn't be fetched
+  definitionName,
+  isLoading = false,
+  selectedDefinition = {},
+}) => {
+  // If we have no selectedDefinition, return error components;
+  if (!Object.keys(selectedDefinition).length) {
+    const NoDefinitionError = () => (
+      definitionName ?
+        <ErrorComponent>
+          <FormattedMessage id="ui-dashboard.error.noWidgetDefinitionForName" values={{ defName: definitionName }} />
+        </ErrorComponent> :
+        <ErrorComponent>
+          <FormattedMessage id="ui-dashboard.error.noWidgetDefinition" />
+        </ErrorComponent>
+    );
+
+    return {
+      WidgetComponent: NoDefinitionError,
+      WidgetFormComponent: NoDefinitionError,
+      submitManipulation: noop,
+      widgetToInitialValues: noop,
+      createInitialValues: noop,
+    };
+  }
+
+  const { type: { name: widgetType = '' } = {} } = selectedDefinition;
   const componentBundle = {};
 
   const WidgetComponentError = () => (
@@ -40,9 +71,9 @@ const getComponentsFromType = (widgetType = '', isLoading = false) => {
     return {
       WidgetComponent: () => (<Spinner className={css.spinner} />),
       WidgetFormComponent: () => (<Spinner className={css.spinner} />),
-      submitManipulation: (props) => (props),
-      widgetToInitialValues: (props) => (props),
-      createInitialValues: (props) => (props),
+      submitManipulation: noop,
+      widgetToInitialValues: noop,
+      createInitialValues: noop,
     };
   }
 
@@ -60,13 +91,13 @@ const getComponentsFromType = (widgetType = '', isLoading = false) => {
     default:
       componentBundle.WidgetComponent = WidgetComponentError;
       componentBundle.WidgetFormComponent = WidgetFormComponentError;
-      componentBundle.submitManipulation = (props) => (props);
-      componentBundle.widgetToInitialValues = (props) => (props);
-      componentBundle.createInitialValues = (props) => (props);
+      componentBundle.submitManipulation = noop;
+      componentBundle.widgetToInitialValues = noop;
+      componentBundle.createInitialValues = noop;
   }
 
   return componentBundle;
 };
 
-export default getComponentsFromType;
+export default getComponentsFromDefinition;
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,2 +1,2 @@
 export { default as ignoreArrayOrderEqualityFunc } from './ignoreArrayOrderEqualityFunc';
-export { default as getComponentsFromType } from './getComponentsFromType';
+export { default as getComponentsFromDefinition } from './getComponentsFromDefinition';

--- a/translations/ui-dashboard/en.json
+++ b/translations/ui-dashboard/en.json
@@ -11,6 +11,8 @@
   "error.noWidgetComponentForType": "No widget component for type: {widgetType}",
   "error.noWidgetFormComponentForType": "No widget form component for type: {widgetType}",
   "error.duplicateColumn": "Duplicate column, please rectify",
+  "error.noWidgetDefinition": "No definition found for widget",
+  "error.noWidgetDefinitionForName": "Could not load widget definition: {defName}",
   "canvas.actions": "Actions",
   "httpError": "HTTPError: {errorCode} {errorText}",
   "appMenu.keyboardShortcuts": "Keyboard shortcuts",


### PR DESCRIPTION
feat: Error handling

Added a bunch of improved error handling and surfacing behaviour.

* Missing widget definitions are no longer surfaced with a "missing type" error component.
* Missing widget definitions now show error component in widget form instead of blank screen
* renamed getComponentsFromType to getComponentsFromDefinition, and the syntax now passes in a fetched definition -- this could possibly be improved in future. Also can optionally pass in definition name to allow for error component to render the missing definition name.
* ErrorComponent now stretches to fill available height

refs SI-41 and SI-34 (Kind of... tangentially related)