### PR TITLE
SI-41: Improve error handling

### DIFF
--- a/src/components/WidgetForm/WidgetForm.js
+++ b/src/components/WidgetForm/WidgetForm.js
@@ -135,6 +135,8 @@ const WidgetForm = ({
     ...widgetDefinitions.map((wd, index) => ({ value: index, label: wd.name }))
   ];
 
+  console.log("VALUES: %o", values)
+
   return (
     <>
       <HasCommand
@@ -201,7 +203,7 @@ const WidgetForm = ({
                 </KeyValue>
               </Col>
             </Row>
-            {values.definition && !areDefinitionsLoading && WidgetFormComponent &&
+            {!!selectedDefinition && !areDefinitionsLoading && !!WidgetFormComponent &&
               <Field
                 name="widgetConfig"
                 render={() => (

--- a/src/components/WidgetForm/WidgetForm.js
+++ b/src/components/WidgetForm/WidgetForm.js
@@ -135,8 +135,6 @@ const WidgetForm = ({
     ...widgetDefinitions.map((wd, index) => ({ value: index, label: wd.name }))
   ];
 
-  console.log("VALUES: %o", values)
-
   return (
     <>
       <HasCommand


### PR DESCRIPTION
fix: Definition not present on edit

On edit of a widget, the `values.definition` was 0, causing a render of just `0`. This has been rectified by swapping to check existence of state "selectedDefinition".

(The way this works is a little arkane, and may be worth rewiring at some point, but for now it works fine)

SI-41